### PR TITLE
fix: pin base image to ubuntu:24.04 for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM ubuntu:latest
+FROM ubuntu:24.04
 
 # Set environment variables to avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Update package list and install Hollywood with recommended packages
+# Pin the base image for reproducible builds and combine RUN layers to reduce image size
 RUN apt-get update && \
     apt-get install -y --install-recommends hollywood && \
     apt-get clean && \


### PR DESCRIPTION
## Summary

Pins the Docker base image from `ubuntu:latest` to `ubuntu:24.04` for reproducible builds.

## Problem

Using `ubuntu:latest` can cause unexpected breakages when Ubuntu releases a new LTS and the tag moves to a new version. This makes builds non-reproducible — the same Dockerfile could produce different results today vs. next month.

## Changes

- Pin base image from `ubuntu:latest` → `ubuntu:24.04` (current LTS)
- Add a clarifying comment about why RUN layers are combined (to reduce image size)

## Benefits

- **Reproducible builds**: Same Dockerfile always produces the same result
- **Predictable CI**: No surprises from base image version drift
- **Explicit intent**: Makes the target OS version clear to anyone reading the Dockerfile
- `ubuntu:24.04` is the latest LTS and will be supported until 2029

If updating to a new LTS is desired in the future, it can be done as an intentional version bump rather than an implicit surprise.