### PR TITLE
docs: explain -it flags and add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Build context for this image only needs the Dockerfile.
+# Excluding these keeps context small and avoids leaking repo
+# metadata into the build.
+.git
+.github
+*.md
+LICENSE
+renovate.json

--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ Hollywood is a Debian package that fills your console with Hollywood-style "hack
 
 - Docker
 - Terminal that supports TTY/PTY allocation
+
+The `docker run` commands above use `-it` so your terminal stays attached:
+- `-i` keeps STDIN open so Hollywood can read keyboard input
+- `-t` allocates a pseudo-TTY, which Hollywood needs to render its split-screen UI
+
+If you see `the input device is not a TTY`, you forgot `-t` or are piping into `docker run` (for example, in a script or CI). Use `--tty` or run from an interactive shell instead.
+
+To stop Hollywood, press `q` inside the terminal or quit the container with `Ctrl+C`.


### PR DESCRIPTION
On behalf of @project516

The README used `-it` in every `docker run` example but never said what those flags do or what to do when something goes wrong. The most common snag with this image is `the input device is not a TTY`, which happens when the container is launched from a script or CI run without a terminal. This PR adds a short explanation of `-i` and `-t` and how to stop the container, so the docs answer that question up front.

I also added a `.dockerignore`. The build only needs the `Dockerfile`, but without a `.dockerignore` the entire repository (the `.git` directory, `.github` workflows, README, LICENSE, renovate config) gets sent to the daemon as build context. Excluding those keeps the context small and avoids sending repo metadata into the build.

Changes:
- README: explain `-i`/`-t`, the `not a TTY` error, and how to stop Hollywood
- Add `.dockerignore` excluding `.git`, `.github`, `*.md`, `LICENSE`, `renovate.json`

Neither change alters the image itself.